### PR TITLE
Connects to #52. Expand rclick range

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -7,7 +7,12 @@ Program: Google Chrome
 # KC3, KCV, KCT, and EO
 RecoveryMethod: KC3
 
+# Specifies the desired # of menus to randomly walk through. If youdon't like how
+# the script takes a winding path to a particular screen, lower this or set it to 0.
 Paranoia = 3
+
+# If you have a slow computer/network connection, you may encounter frequent FindFailed
+# errors. increase this value to increase the length of all sleep/wait timers to avoid this.
 SleepModifier = 0
 
 [Expeditions]

--- a/config.ini
+++ b/config.ini
@@ -7,6 +7,9 @@ Program: Google Chrome
 # KC3, KCV, KCT, and EO
 RecoveryMethod: KC3
 
+Paranoia = 3
+SleepModifier = 0
+
 [Expeditions]
 # Set to True if you want kancolle-auto to run expeditions; False if not.
 Enabled: True

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -121,7 +121,7 @@ class Combat:
                 # Ended on resource nodes. Leave sortie.
                 if self.kc_window.exists('next_alt.png'):
                     log_success("Sortie complete!")
-                    check_and_click(self.kc_window, 'next_alt.png')
+                    check_and_click(self.kc_window, 'next_alt.png', [-700, 30, -400, 30])
                     sortie_underway = False
                     return self.damage_counts
                 # If night battle prompt, proceed based on node and user config
@@ -137,20 +137,20 @@ class Combat:
                         log_msg("Declining night battle!")
                         check_and_click(self.kc_window, 'combat_nb_retreat.png')
                 # Click through post-battle report
-                wait_and_click(self.kc_window, 'next.png', 30)
+                wait_and_click(self.kc_window, 'next.png', 30, [-700, 30, -400, 30])
                 sleep(3)
                 # Tally damages at post-battle report screen
                 self.tally_damages()
-                wait_and_click(self.kc_window, 'next.png', 30)
+                wait_and_click(self.kc_window, 'next.png', 30, [-700, 30, -400, 30])
                 sleep(3)
                 # Check to see if we're at combat retreat/continue screen or
                 # item/ship reward screen(s)
                 if not self.kc_window.exists('combat_retreat.png'):
                     sleep(3)
                     if not (self.kc_window.exists('menu_main_sortie.png') or self.kc_window.exists('combat_flagship_dmg.png')):
-                        wait_and_click(self.kc_window, 'next_alt.png', 20)
+                        wait_and_click(self.kc_window, 'next_alt.png', 20, [-700, 30, -400, 30])
                         sleep(5)
-                        if check_and_click(self.kc_window, 'next_alt.png'):
+                        if check_and_click(self.kc_window, 'next_alt.png', [-700, 30, -400, 30]):
                             sleep(3)
                 if self.kc_window.exists('combat_flagship_dmg.png'):
                     wait_and_click(self.kc_window, 'combat_flagship_dmg.png')
@@ -199,7 +199,7 @@ class Combat:
             or self.kc_window.exists('catbomb.png')):
             sleep(2)
         # If compass, press it
-        if check_and_click(self.kc_window, 'compass.png'):
+        if check_and_click(self.kc_window, 'compass.png', [-300, 400, -200, 200]):
             # Now check for formation select, night battle prompt, or
             # post-battle report
             log_msg("Spinning compass!")

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -87,8 +87,8 @@ class Combat:
                 self.next_sortie_time_set(0, 15)
                 return self.damage_counts
         wait_and_click(self.kc_window, 'decision.png')
+        sleep(1)
         self.kc_window.mouseMove(Location(self.kc_window.x + 100, self.kc_window.y + 100))
-        sleep(2)
         # Taly damages
         self.tally_damages()
         # Check for resupply needs

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -1,7 +1,8 @@
 # Combat list.
 from sikuli import *
 import datetime
-from util import (sleep, get_rand, rclick, check_and_click, wait_and_click, rnavigation,
+from random import randint
+from util import (sleep, rclick, check_and_click, wait_and_click, rnavigation,
     check_timer, log_msg, log_success, log_warning, log_error)
 
 Settings.OcrTextRead = True
@@ -163,7 +164,7 @@ class Combat:
                 nodes_run += 1
                 # Set next sortie time to soon in case we have no failures or
                 # additional nodes
-                self.next_sortie_time_set(0, get_rand(1, 3))
+                self.next_sortie_time_set(0, randint(1, 4))
                 # If required number of nodes have been run, fall back
                 if nodes_run >= self.nodes:
                     log_msg("Ran the required number of nodes. Falling back!")
@@ -181,7 +182,7 @@ class Combat:
         else:
             if self.kc_window.exists('combat_nogo_repair.png'):
                 log_warning("Cannot sortie due to ships under repair!")
-                self.next_sortie_time_set(0, get_rand(5, 5))
+                self.next_sortie_time_set(0, randint(5, 10))
                 # Expand on this so it goes to repair menu and recheck?
             elif self.kc_window.exists('combat_nogo_resupply.png'):
                 log_warning("Cannot sortie due to ships needing resupply!")

--- a/kancolle_auto.sikuli/expedition.sikuli/expedition.py
+++ b/kancolle_auto.sikuli/expedition.sikuli/expedition.py
@@ -44,8 +44,8 @@ class Expedition:
                 log_warning("Expedition is already running: %s" % expedition)
             return False
         wait_and_click(self.kc_window, 'decision.png')
-        self.kc_window.mouseMove(Location(self.kc_window.x + 100, self.kc_window.y + 100))
         sleep(1)
+        self.kc_window.mouseMove(Location(self.kc_window.x + 100, self.kc_window.y + 100))
         log_msg("Trying to send out fleet %s for expedition %s" % (expedition.fleet_id, expedition.id))
         # Select fleet (no need if fleet is 2 as it's selected by default)
         if expedition.fleet_id != 2:

--- a/kancolle_auto.sikuli/expedition.sikuli/expedition.py
+++ b/kancolle_auto.sikuli/expedition.sikuli/expedition.py
@@ -1,7 +1,7 @@
 # Ensei (expedition) task list.
 from sikuli import *
 import datetime
-from util import (sleep, get_rand, rclick, check_and_click, wait_and_click, rnavigation,
+from util import (sleep, rclick, check_and_click, wait_and_click, rnavigation,
     check_timer, log_msg, log_success, log_warning, log_error)
 
 class Expedition:

--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -2,7 +2,7 @@ import datetime, os, sys, random, ConfigParser
 sys.path.append(os.getcwd())
 import expedition as expedition_module
 import combat as combat_module
-from util import (sleep, get_rand, rclick, check_and_click, wait_and_click, rnavigation,
+from util import (get_util_config, sleep, rclick, check_and_click, wait_and_click, rnavigation,
     check_timer, log_msg, log_success, log_warning, log_error)
 
 # Sikuli settings
@@ -275,6 +275,7 @@ def refresh_kancolle(e):
 def init():
     global kc_window, fleet_returned, expedition_item, combat_item, settings
     get_config()
+    get_util_config()
     log_success("Starting kancolle_auto")
     try:
         # Go home

--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -93,7 +93,7 @@ def check_expedition():
                     if fleet_id == expedition.fleet_id:
                         # Remove the associated expedition from running_expedition_list
                         expedition_item.running_expedition_list.remove(expedition)
-        wait_and_click(kc_window, 'next.png', [-700, 30, -400, 30])
+        wait_and_click(kc_window, 'next.png', WAITLONG, [-700, 30, -400, 30])
         kc_window.wait('menu_main_sortie.png', WAITLONG)
         check_expedition()
         return True

--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -79,7 +79,7 @@ def check_expedition():
     log_msg("Are there returning expeditions to receive?")
     if check_and_click(kc_window, 'expedition_finish.png'):
         sleep(3)
-        wait_and_click(kc_window, 'next.png', WAITLONG)
+        wait_and_click(kc_window, 'next.png', WAITLONG, [-700, 30, -400, 30])
         # Identify which fleet came back
         if kc_window.exists(Pattern('returned_fleet2.png').exact()): fleet_id = 2
         elif kc_window.exists(Pattern('returned_fleet3.png').exact()): fleet_id = 3
@@ -93,7 +93,7 @@ def check_expedition():
                     if fleet_id == expedition.fleet_id:
                         # Remove the associated expedition from running_expedition_list
                         expedition_item.running_expedition_list.remove(expedition)
-        wait_and_click(kc_window, 'next.png')
+        wait_and_click(kc_window, 'next.png', [-700, 30, -400, 30])
         kc_window.wait('menu_main_sortie.png', WAITLONG)
         check_expedition()
         return True

--- a/kancolle_auto.sikuli/util.sikuli/util.py
+++ b/kancolle_auto.sikuli/util.sikuli/util.py
@@ -26,7 +26,6 @@ def get_util_config():
 # The lower and upper bounds can be adjusted by the SleepModifier setting.
 def sleep(base, flex=-1):
     global util_settings
-    print util_settings
     if flex == -1:
         tsleep(uniform(base + util_settings['sleep_mod'], base * 2 + util_settings['sleep_mod']))
     else:
@@ -60,20 +59,21 @@ def check_timer(kc_window, timer_img, width):
 # Random Click action. Offsets the mouse into a random point within the
 # matching image/pattern before clicking.
 def rclick(kc_window, pic, expand=[]):
-    # This slows down the click actions, but it looks for the pattern and
-    # finds the size of the image from the resulting Pattern object.
-    m = match(r'M\[\d+\,\d+ (\d+)x(\d+)\]', str(find(pic)))
-    if m:
-        # If a match is found and the x,y sizes can be ascertained, generate
-        # the random offsets. Otherwise, just click the damn middle.
-        if len(expand) == 0:
+    if len(expand) == 0:
+        # This slows down the click actions, but it looks for the pattern and
+        # finds the size of the image from the resulting Pattern object.
+        m = match(r'M\[\d+\,\d+ (\d+)x(\d+)\]', str(find(pic)))
+        if m:
+            # If a match is found and the x,y sizes can be ascertained, generate
+            # the random offsets. Otherwise, just click the damn middle.
             x_width = int(m.group(1)) / 2
             y_height = int(m.group(2)) / 2
             expand.extend([-x_width, x_width, -y_height, y_height])
+    if len(expand) == 4:
         if isinstance(pic, str):
-            pic = Pattern(pic).targetOffset(int(uniform(expand[0], expand[1])), int(uniform(expand[3], expand[4])))
+            pic = Pattern(pic).targetOffset(int(uniform(expand[0], expand[1])), int(uniform(expand[2], expand[3])))
         elif isinstance(pic, Pattern):
-            pic = pic.targetOffset(int(uniform(expand[0], expand[1])), int(uniform(expand[3], expand[4])))
+            pic = pic.targetOffset(int(uniform(expand[0], expand[1])), int(uniform(expand[2], expand[3])))
     kc_window.click(pic)
 
 # Random navigation actions.

--- a/kancolle_auto.sikuli/util.sikuli/util.py
+++ b/kancolle_auto.sikuli/util.sikuli/util.py
@@ -68,7 +68,7 @@ def rclick(kc_window, pic, expand=[]):
             # the random offsets. Otherwise, just click the damn middle.
             x_width = int(m.group(1)) / 2
             y_height = int(m.group(2)) / 2
-            expand.extend([-x_width, x_width, -y_height, y_height])
+            expand = [-x_width, x_width, -y_height, y_height]
     if len(expand) == 4:
         if isinstance(pic, str):
             pic = Pattern(pic).targetOffset(int(uniform(expand[0], expand[1])), int(uniform(expand[2], expand[3])))

--- a/kancolle_auto.sikuli/util.sikuli/util.py
+++ b/kancolle_auto.sikuli/util.sikuli/util.py
@@ -59,19 +59,21 @@ def check_timer(kc_window, timer_img, width):
 
 # Random Click action. Offsets the mouse into a random point within the
 # matching image/pattern before clicking.
-def rclick(kc_window, pic):
+def rclick(kc_window, pic, expand=[]):
     # This slows down the click actions, but it looks for the pattern and
     # finds the size of the image from the resulting Pattern object.
     m = match(r'M\[\d+\,\d+ (\d+)x(\d+)\]', str(find(pic)))
     if m:
         # If a match is found and the x,y sizes can be ascertained, generate
         # the random offsets. Otherwise, just click the damn middle.
-        x_width = int(m.group(1)) / 2
-        y_height = int(m.group(2)) / 2
+        if len(expand) == 0:
+            x_width = int(m.group(1)) / 2
+            y_height = int(m.group(2)) / 2
+            expand.extend([-x_width, x_width, -y_height, y_height])
         if isinstance(pic, str):
-            pic = Pattern(pic).targetOffset(int(uniform(-x_width, x_width)), int(uniform(-y_height, y_height)))
+            pic = Pattern(pic).targetOffset(int(uniform(expand[0], expand[1])), int(uniform(expand[3], expand[4])))
         elif isinstance(pic, Pattern):
-            pic = pic.targetOffset(int(uniform(-x_width, x_width)), int(uniform(-y_height, y_height)))
+            pic = pic.targetOffset(int(uniform(expand[0], expand[1])), int(uniform(expand[3], expand[4])))
     kc_window.click(pic)
 
 # Random navigation actions.
@@ -234,18 +236,18 @@ def rnavigation_chooser(options, exclude):
     return choice([i for i in options if i not in exclude])
 
 # common Sikuli actions
-def check_and_click(kc_window, pic):
+def check_and_click(kc_window, pic, expand=[]):
     if kc_window.exists(pic):
-        rclick(kc_window, pic)
+        rclick(kc_window, pic, expand)
         return True
     return False
 
-def wait_and_click(kc_window, pic, time=5):
+def wait_and_click(kc_window, pic, time=5, expand=[]):
     if time:
         kc_window.wait(pic, time)
     else:
         kc_window.wait(pic)
-    rclick(kc_window, pic)
+    rclick(kc_window, pic, expand)
 
 # log colors
 class color:

--- a/kancolle_auto.sikuli/util.sikuli/util.py
+++ b/kancolle_auto.sikuli/util.sikuli/util.py
@@ -1,20 +1,36 @@
+import ConfigParser
 from sikuli import *
 from random import uniform, randint, choice
 from time import sleep as tsleep, strftime
 from re import match
 
 Settings.OcrTextRead = True
+util_settings = {}
 
-# Custom sleep() function to make the sleep period more variable. Maximum
-# sleep length is 2 * sec
-def sleep(sec):
-    tsleep(uniform(sec, sec * 2))
+def get_util_config():
+    global util_settings
+    log_msg("Reading config file")
+    # Change paths and read config.ini
+    os.chdir(getBundlePath())
+    os.chdir('..')
+    config = ConfigParser.ConfigParser()
+    config.read('config.ini')
+    # Set user settings
+    # 'General'/misc settings
+    util_settings['paranoia'] = 0 if config.getint('General', 'Paranoia') < 0 else config.getint('General', 'Paranoia')
+    util_settings['sleep_mod'] = 0 if config.getint('General', 'SleepModifier') < 0 else config.getint('General', 'SleepModifier')
 
-# Custom function to get some pseudo-random value. Here in case variability is
-# needed in a non-sleep() function. Maximum return is base + flex.
-# value is 2 * integer
-def get_rand(base, flex):
-    return randint(base, base + flex)
+# Custom sleep() function to make the sleep period more variable. Takes base (minimum)
+# sleep length and flex sleep length, for a max sleep length of base + flex. If
+# the flex sleep length is not defined, the max sleep length is base * 2.
+# The lower and upper bounds can be adjusted by the SleepModifier setting.
+def sleep(base, flex=-1):
+    global util_settings
+    print util_settings
+    if flex == -1:
+        tsleep(uniform(base + util_settings['sleep_mod'], base * 2 + util_settings['sleep_mod']))
+    else:
+        tsleep(uniform(base + util_settings['sleep_mod'], flex + util_settings['sleep_mod']))
 
 # Custom function to get timer value of Kancolle (in ##:##:## format). Attempts
 # to fix values in case OCR grabs the wrong characters.
@@ -59,7 +75,8 @@ def rclick(kc_window, pic):
     kc_window.click(pic)
 
 # Random navigation actions.
-def rnavigation(kc_window, destination, max=3):
+def rnavigation(kc_window, destination, max=0):
+    global util_settings
     # Look at all the things we can click!
     menu_main_options = ['menu_main_sortie.png', 'menu_main_fleetcomp.png', 'menu_main_resupply.png',
         'menu_main_equip.png', 'menu_main_repair.png', 'menu_main_development.png']
@@ -69,7 +86,17 @@ def rnavigation(kc_window, destination, max=3):
         'menu_side_repair.png', 'menu_side_development.png']
     menu_sortie_options = ['sortie_combat.png', 'sortie_expedition.png', 'sortie_pvp.png']
     menu_sortie_top_options = ['sortie_top_combat.png', 'sortie_top_expedition.png', 'sortie_top_pvp.png']
-    menu_loop_count = randint(0, max)
+    # Set max evasion steps
+    if max == 0:
+        # If max evasion was not defined by the function call, use paranoia
+        # setting from config
+        max = util_settings['paranoia']
+    else:
+        if util_settings['paranoia'] < max:
+            # If max evasion was defined by the function call, but the paranoia
+            # setting from config is shorter, use the paranoia setting
+            max = util_settings['paranoia']
+    evade_count = randint(0, max)
     # Figure out where we are
     current_location = ''
     if kc_window.exists('menu_main_sortie.png'):
@@ -89,105 +116,105 @@ def rnavigation(kc_window, destination, max=3):
             pass
         elif destination == 'refresh_home':
             # Refresh home
-            log_msg("Refreshing home with %d or less sidestep(s)!" % (menu_loop_count))
+            log_msg("Refreshing home with %d or less sidestep(s)!" % (evade_count))
             rchoice = rnavigation_chooser(menu_top_options + menu_main_options, [])
             wait_and_click(kc_window, rchoice)
             sleep(2)
-            menu_loop_count -= 1
+            evade_count -= 1
             if rchoice.startswith('menu_top'):
                 # At top menu item; hit the home button until we get home (Akashi/Ooyodo, go away)
                 while not kc_window.exists('menu_main_sortie.png'):
                     wait_and_click(kc_window, 'menu_top_home.png', 10)
                     sleep(2)
             elif rchoice.startswith('menu_main'):
-                if menu_loop_count == 0:
+                if evade_count == 0:
                     wait_and_click(kc_window, 'menu_side_home.png')
                 else:
                     rchoice = rnavigation_chooser(menu_side_options, ['menu_side_' + rchoice[10:]])
-                    while menu_loop_count > 0:
+                    while evade_count > 0:
                         rchoice = rnavigation_chooser(menu_side_options, [rchoice])
                         wait_and_click(kc_window, rchoice)
                         sleep(2)
-                        menu_loop_count -= 1
+                        evade_count -= 1
                     wait_and_click(kc_window, 'menu_side_home.png')
         elif destination in ['combat', 'expedition']:
             # Go to combat and expedition menu
-            log_msg("Navigating to %s menu with %d sidestep(s)!" % (destination, menu_loop_count))
+            log_msg("Navigating to %s menu with %d sidestep(s)!" % (destination, evade_count))
             wait_and_click(kc_window, 'menu_main_sortie.png')
             kc_window.mouseMove(Location(kc_window.x + 100, kc_window.y + 100))
             sleep(2)
-            if menu_loop_count == 0:
+            if evade_count == 0:
                 wait_and_click(kc_window, 'sortie_' + destination + '.png')
             else:
                 rchoice = rnavigation_chooser(menu_sortie_options, ['sortie_' + destination + '.png'])
                 wait_and_click(kc_window, rchoice)
                 kc_window.mouseMove(Location(kc_window.x + 100, kc_window.y + 100))
-                menu_loop_count -= 1
-                while menu_loop_count > 0:
+                evade_count -= 1
+                while evade_count > 0:
                     if rchoice.startswith('sortie_top'):
                         rchoice = rnavigation_chooser(menu_sortie_top_options, [rchoice, 'sortie_top_' + destination + '.png'])
                     else:
                         rchoice = rnavigation_chooser(menu_sortie_top_options, ['sortie_top_' + rchoice[7:], 'sortie_top_' + destination + '.png'])
                     wait_and_click(kc_window, rchoice)
                     sleep(2)
-                    menu_loop_count -= 1
+                    evade_count -= 1
                 wait_and_click(kc_window, 'sortie_top_' + destination + '.png')
         else:
             # Go to and side menu sub screen
-            log_msg("Navigating to %s screen with %d sidestep(s)!" % (destination, menu_loop_count))
-            if menu_loop_count == 0:
+            log_msg("Navigating to %s screen with %d sidestep(s)!" % (destination, evade_count))
+            if evade_count == 0:
                 wait_and_click(kc_window, 'menu_main_' + destination + '.png')
             else:
                 rchoice = rnavigation_chooser(menu_main_options, ['menu_main_' + destination + '.png'])
                 wait_and_click(kc_window, rchoice)
-                menu_loop_count -= 1
-                while menu_loop_count > 0:
+                evade_count -= 1
+                while evade_count > 0:
                     if rchoice.startswith('menu_main'):
                         rchoice = rnavigation_chooser(menu_side_options, ['menu_side_' + rchoice[10:], 'sortie_top_' + destination + '.png'])
                     else:
                         rchoice = rnavigation_chooser(menu_side_options, [rchoice, 'sortie_top_' + destination + '.png'])
                     wait_and_click(kc_window, rchoice)
                     sleep(2)
-                    menu_loop_count -= 1
+                    evade_count -= 1
                 wait_and_click(kc_window, 'menu_side_' + destination + '.png')
         sleep(2)
     if current_location == 'sidemenu':
         # Starting from a main menu item screen
         if destination == 'home' or destination == 'refresh_home':
             # Go or refresh home
-            log_msg("Going home with %d or less sidestep(s)!" % (menu_loop_count))
-            if menu_loop_count == 0:
+            log_msg("Going home with %d or less sidestep(s)!" % (evade_count))
+            if evade_count == 0:
                 wait_and_click(kc_window, 'menu_side_home.png')
             else:
                 rchoice = rnavigation_chooser(menu_top_options + menu_side_options, [])
-                while menu_loop_count > 0:
+                while evade_count > 0:
                     rchoice = rnavigation_chooser(menu_top_options + menu_side_options, [rchoice])
                     wait_and_click(kc_window, rchoice)
                     sleep(2)
-                    menu_loop_count -= 1
+                    evade_count -= 1
                     if rchoice.startswith('menu_top'):
                         # At top menu item; hit the home button until we get home (Akashi/Ooyodo, go away)
                         while not kc_window.exists('menu_main_sortie.png'):
                             wait_and_click(kc_window, 'menu_top_home.png', 10)
                             sleep(2)
                         # This takes us back to home immediately, so no more random menus
-                        menu_loop_count = 0
+                        evade_count = 0
                     else:
                         # Still at side menu item, so continue as normal
-                        if menu_loop_count == 0:
+                        if evade_count == 0:
                             # Unless that was the last random menu item; then go home
                             wait_and_click(kc_window, 'menu_side_home.png')
         else:
             # Go to another main menu item screen
-            log_msg("Navigating to %s screen with %d sidestep(s)!" % (destination, menu_loop_count))
-            if menu_loop_count == 0:
+            log_msg("Navigating to %s screen with %d sidestep(s)!" % (destination, evade_count))
+            if evade_count == 0:
                 wait_and_click(kc_window, 'menu_side_' + destination + '.png')
             else:
                 rchoice = rnavigation_chooser(menu_side_options, ['menu_side_' + destination + '.png'])
-                while menu_loop_count > 0:
+                while evade_count > 0:
                     rchoice = rnavigation_chooser(menu_side_options, [rchoice, 'menu_side_' + destination + '.png'])
                     wait_and_click(kc_window, rchoice)
-                    menu_loop_count -= 1
+                    evade_count -= 1
                     sleep(2)
                 wait_and_click(kc_window, 'menu_side_' + destination + '.png')
         sleep(2)


### PR DESCRIPTION
For `compass.png`, `next.png`, and `next_alt.png` clicks, it really doesn't matter where in the screen you press. Ideally, the valid click area would be all over the screen, not just the specific area, so the valid click areas for these images have been expanded. Connects to #52.

Other changes:
- Optimize `rclick` function
- Add Paranoia and SleepModifier config options
- Remove `get_rand` function
