### PR TITLE
Fixes #17. More robust repair module

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -27,7 +27,7 @@ Fleet4: 21
 
 [Combat]
 # Set to True if you want Fleet 1 to run combat sorties; False if not.
-Enabled: True
+Enabled: False
 
 # Set which area you want to sortie to.
 # Example 1: if you're running 3-2-A, set this to '3'

--- a/config.ini
+++ b/config.ini
@@ -83,4 +83,4 @@ CheckFatigue = True
 
 # Whether or not to sortie when the port (ship slots) is full. Set to True if you do not want
 # sorties to occur when your port is full.
-PortCheck = True
+PortCheck = False

--- a/config.ini
+++ b/config.ini
@@ -22,8 +22,8 @@ Enabled: True
 # Define which Expedition a fleet should go on. If you do not have a Fleet unlocked
 # or you don't want it to run an expedition, just leave its value blank.
 Fleet2: 2
-Fleet3: 21
-Fleet4: 38
+Fleet3: 5
+Fleet4: 21
 
 [Combat]
 # Set to True if you want Fleet 1 to run combat sorties; False if not.

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -22,6 +22,7 @@ class Combat:
         self.retreat_limit = settings['retreat_limit']
         self.repair_limit = settings['repair_limit']
         self.repair_time_limit = settings['repair_time_limit']
+        self.repair_timers = []
         self.check_fatigue = settings['check_fatigue']
         self.port_check = settings['port_check']
         self.damage_counts = [0, 0, 0]
@@ -232,7 +233,17 @@ class Combat:
     # next sortie time accordingly
     def go_repair(self):
         empty_docks = 0
+        self.repair_timers = []
         rnavigation(self.kc_window, 'repair')
+        # Are there any pre-existing repairs happening?
+        if self.kc_window.exists('repair_timer_alt.png'):
+            for i in self.kc_window.findAll('repair_timer_alt.png'):
+                timer = i.right(100).text()
+                print timer
+                self.repair_timers.append(timer)
+            self.repair_timers.sort()
+
+
         if self.kc_window.exists('repair_empty.png'):
             for i in self.kc_window.findAll('repair_empty.png'):
                 empty_docks += 1
@@ -284,9 +295,11 @@ class Combat:
                                 sleep(10)
                         else:
                             # Try setting next sortie time according to repair timer
-                            log_success("Repair should be done at %s" % (datetime.datetime.now()
-                                + datetime.timedelta(hours=int(repair_timer[0:2]), minutes=int(repair_timer[3:5]))).strftime("%Y-%m-%d %H:%M:%S"))
+                            timer = self.timer_end(int(repair_timer[0:2]), int(repair_timer[3:5])
+                            log_success("Repair should be done at %s" % (timer.strftime("%Y-%m-%d %H:%M:%S"))
                             self.next_sortie_time_set(int(repair_timer[0:2]), int(repair_timer[3:5]))
+                            self.repair_timers.append(timer)
+                            self.repair_timers.sort()
                             empty_docks -= 1
                     wait_and_click(self.kc_window, 'repair_start.png', 10)
                     wait_and_click(self.kc_window, 'repair_start_confirm.png', 10)
@@ -301,3 +314,7 @@ class Combat:
         proposed_time = datetime.datetime.now() + datetime.timedelta(hours=hours, minutes=minutes)
         if proposed_time > self.next_sortie_time:
             self.next_sortie_time = proposed_time
+
+    def timer_end(self, hours, minutes):
+        return datetime.datetime.now() + datetime.timedelta(hours=hours, minutes=minutes)
+

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -235,21 +235,22 @@ class Combat:
         empty_docks = 0
         self.repair_timers = []
         rnavigation(self.kc_window, 'repair')
+        self.kc_window.wait('repair_screen_check.png')
         # Are there any pre-existing repairs happening?
         if self.kc_window.exists('repair_timer_alt.png'):
             for i in self.kc_window.findAll('repair_timer_alt.png'):
-                timer = i.right(100).text()
+                timer = check_timer(self.kc_window, i, 'l', 100)
                 print timer
                 self.repair_timers.append(timer)
             self.repair_timers.sort()
-
-
+        print self.repair_timers
         if self.kc_window.exists('repair_empty.png'):
             for i in self.kc_window.findAll('repair_empty.png'):
                 empty_docks += 1
         else:
-            self.next_sortie_time_set(0, 20)
-            log_warning("Cannot repair; docks are full. Checking back in 20 minutes!")
+            self.next_sortie_time_set()
+            log_warning("Cannot repair; docks are full. Checking back later!")
+        print empty_docks
         if empty_docks != 0:
             repair_queue = empty_docks if self.count_damage_above_limit('repair') > empty_docks else self.count_damage_above_limit('repair')
             while empty_docks > 0 and repair_queue > 0:
@@ -285,7 +286,7 @@ class Combat:
                             sleep(10)
                     else:
                         # Otherwise, act accordingly to timer and repair timer limit
-                        repair_timer = check_timer(self.kc_window, 'repair_timer.png', 80)
+                        repair_timer = check_timer(self.kc_window, 'repair_timer.png', 'r', 80)
                         if int(repair_timer[0:2]) >= self.repair_time_limit:
                             # Use bucket if the repair time is longer than desired
                             log_success("Repair time too long... using bucket!")
@@ -295,8 +296,8 @@ class Combat:
                                 sleep(10)
                         else:
                             # Try setting next sortie time according to repair timer
-                            timer = self.timer_end(int(repair_timer[0:2]), int(repair_timer[3:5])
-                            log_success("Repair should be done at %s" % (timer.strftime("%Y-%m-%d %H:%M:%S"))
+                            timer = self.timer_end(int(repair_timer[0:2]), int(repair_timer[3:5]))
+                            log_success("Repair should be done at %s" % timer.strftime("%Y-%m-%d %H:%M:%S"))
                             self.next_sortie_time_set(int(repair_timer[0:2]), int(repair_timer[3:5]))
                             self.repair_timers.append(timer)
                             self.repair_timers.sort()
@@ -310,11 +311,13 @@ class Combat:
 
     # Set next sortie time; if the proposed time is longer than the previously
     # stored time, replace. Otherwise, keep the older (longer) one
-    def next_sortie_time_set(self, hours, minutes):
-        proposed_time = datetime.datetime.now() + datetime.timedelta(hours=hours, minutes=minutes)
-        if proposed_time > self.next_sortie_time:
-            self.next_sortie_time = proposed_time
+    def next_sortie_time_set(self, hours=-1, minutes=-1):
+        if hours == -1 and minutes == -1:
+            self.next_sortie_time = self.repair_timers[0]
+        else:
+            proposed_time = datetime.datetime.now() + datetime.timedelta(hours=hours, minutes=minutes)
+            if proposed_time > self.next_sortie_time:
+                self.next_sortie_time = proposed_time
 
     def timer_end(self, hours, minutes):
         return datetime.datetime.now() + datetime.timedelta(hours=hours, minutes=minutes)
-

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -237,20 +237,18 @@ class Combat:
         rnavigation(self.kc_window, 'repair')
         self.kc_window.wait('repair_screen_check.png')
         # Are there any pre-existing repairs happening?
-        if self.kc_window.exists('repair_timer_alt.png'):
-            for i in self.kc_window.findAll('repair_timer_alt.png'):
-                timer = check_timer(self.kc_window, i, 'l', 100)
-                print timer
+        if self.kc_window.exists(Pattern('repair_timer_alt.png').similar(0.5)):
+            for i in self.kc_window.findAll(Pattern('repair_timer_alt.png').similar(0.5)):
+                repair_timer = check_timer(self.kc_window, i, 'l', 100)
+                timer = self.timer_end(int(repair_timer[0:2]), int(repair_timer[3:5]))
                 self.repair_timers.append(timer)
             self.repair_timers.sort()
-        print self.repair_timers
         if self.kc_window.exists('repair_empty.png'):
             for i in self.kc_window.findAll('repair_empty.png'):
                 empty_docks += 1
         else:
             self.next_sortie_time_set()
-            log_warning("Cannot repair; docks are full. Checking back later!")
-        print empty_docks
+            log_warning("Cannot repair; docks are full. Checking back at %s!" % self.next_sortie_time.strftime("%Y-%m-%d %H:%M:%S"))
         if empty_docks != 0:
             repair_queue = empty_docks if self.count_damage_above_limit('repair') > empty_docks else self.count_damage_above_limit('repair')
             while empty_docks > 0 and repair_queue > 0:

--- a/kancolle_auto.sikuli/expedition.sikuli/expedition.py
+++ b/kancolle_auto.sikuli/expedition.sikuli/expedition.py
@@ -36,7 +36,7 @@ class Expedition:
                 log_warning("Expedition just returned:  %s" % expedition)
             else:
                 # Expedition is already running
-                expedition_timer = check_timer(self.kc_window, 'expedition_timer.png', 80)
+                expedition_timer = check_timer(self.kc_window, 'expedition_timer.png', 'r', 80)
                 # Set expedition's end time as determined via OCR and add it to
                 # running_expedition_list
                 expedition.check_later(int(expedition_timer[0:2]), int(expedition_timer[3:5]))

--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -154,7 +154,7 @@ def expedition_action(fleet_id):
 # Navigate to and conduct sorties
 def sortie_action():
     global kc_window, fleet_returned, combat_item, settings
-    go_home(True)
+    go_home()
     combat_item.go_sortie()
     fleet_returned[0] = True
     # Check home, repair if needed, and resupply
@@ -282,6 +282,7 @@ def init():
         go_home(True)
         # Define expedition list if expeditions module is enabled
         if settings['expeditions_enabled'] == True:
+            # Resupply fleets if they returned on startup
             if True in fleet_returned:
                 resupply()
                 go_home()
@@ -319,6 +320,9 @@ while True:
                         expedition_action(fleet_id + 1)
         # If combat timer is up, go sortie
         if settings['combat_enabled'] == True:
+            if combat_item.count_damage_above_limit('repair') > 0 and len(combat_item.repair_timers) > 0:
+                if datetime.datetime.now() > combat_item.repair_timers[0]:
+                    combat_item.go_repair()
             if datetime.datetime.now() > combat_item.next_sortie_time:
                 idle = False
                 sortie_action()

--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -154,7 +154,7 @@ def expedition_action(fleet_id):
 # Navigate to and conduct sorties
 def sortie_action():
     global kc_window, fleet_returned, combat_item, settings
-    go_home()
+    go_home(True)
     combat_item.go_sortie()
     fleet_returned[0] = True
     # Check home, repair if needed, and resupply
@@ -318,11 +318,13 @@ while True:
                 for fleet_id, fleet_status in enumerate(fleet_returned):
                     if fleet_status == True and fleet_id != 0:
                         expedition_action(fleet_id + 1)
-        # If combat timer is up, go sortie
+        # If combat timer is up, go do sortie-related stuff
         if settings['combat_enabled'] == True:
+            # If there are ships that still need repair, go take care of them
             if combat_item.count_damage_above_limit('repair') > 0 and len(combat_item.repair_timers) > 0:
                 if datetime.datetime.now() > combat_item.repair_timers[0]:
                     combat_item.go_repair()
+            # If the fleet is ready, go sortie
             if datetime.datetime.now() > combat_item.next_sortie_time:
                 idle = False
                 sortie_action()

--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -278,21 +278,24 @@ def init():
     get_util_config()
     log_success("Starting kancolle_auto")
     try:
+        focus_window()
+        if settings['expeditions_enabled'] == True:
+            # Define expedition list if expeditions module is enabled
+            expedition_item = expedition_module.Expedition(kc_window, settings)
+        if settings['combat_enabled'] == True:
+            # Define combat item if combat module is enabled
+            combat_item = combat_module.Combat(kc_window, settings)
         # Go home
         go_home(True)
-        # Define expedition list if expeditions module is enabled
         if settings['expeditions_enabled'] == True:
             # Resupply fleets if they returned on startup
             if True in fleet_returned:
                 resupply()
                 go_home()
-            expedition_item = expedition_module.Expedition(kc_window, settings)
             # Run expeditions defined in expedition item
             expedition_item.go_expedition()
             expedition_action('all')
-        # Define combat item if combat module is enabled
         if settings['combat_enabled'] == True:
-            combat_item = combat_module.Combat(kc_window, settings)
             # Run sortie defined in combat item
             sortie_action()
     except FindFailed, e:

--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -282,6 +282,9 @@ def init():
         go_home(True)
         # Define expedition list if expeditions module is enabled
         if settings['expeditions_enabled'] == True:
+            if True in fleet_returned:
+                resupply()
+                go_home()
             expedition_item = expedition_module.Expedition(kc_window, settings)
             # Run expeditions defined in expedition item
             expedition_item.go_expedition()

--- a/kancolle_auto.sikuli/util.sikuli/util.py
+++ b/kancolle_auto.sikuli/util.sikuli/util.py
@@ -8,6 +8,7 @@ Settings.OcrTextRead = True
 util_settings = {}
 
 def get_util_config():
+    """Load the settings related to the util module"""
     global util_settings
     log_msg("Reading config file")
     # Change paths and read config.ini
@@ -20,20 +21,31 @@ def get_util_config():
     util_settings['paranoia'] = 0 if config.getint('General', 'Paranoia') < 0 else config.getint('General', 'Paranoia')
     util_settings['sleep_mod'] = 0 if config.getint('General', 'SleepModifier') < 0 else config.getint('General', 'SleepModifier')
 
-# Custom sleep() function to make the sleep period more variable. Takes base (minimum)
-# sleep length and flex sleep length, for a max sleep length of base + flex. If
-# the flex sleep length is not defined, the max sleep length is base * 2.
-# The lower and upper bounds can be adjusted by the SleepModifier setting.
 def sleep(base, flex=-1):
+    """
+    Custom random-variable sleep() function. Sleep length set by this function
+    can vary from base to base * 2, or base to base + flex if flex is provided.
+
+    base - positive int
+    flex - positive int; defaults to -1 to disable
+    """
     global util_settings
     if flex == -1:
         tsleep(uniform(base, base * 2) + util_settings['sleep_mod'])
     else:
         tsleep(uniform(base, flex) + util_settings['sleep_mod'])
 
-# Custom function to get timer value of Kancolle (in ##:##:## format). Attempts
-# to fix values in case OCR grabs the wrong characters.
 def check_timer(kc_window, timer_ref, dir, width):
+    """
+    Function for grabbing valid Kancolle timer readings (##:##:## format).
+    Attempts to fix erroneous OCR reads and repeats readings until a valid
+    timer value is returned.
+
+    kc_window - Sikuli window
+    timer_ref - reference image or reference Match object (returned by findAll, for example)
+    dir - 'l' or 'r'; direction to search for text
+    width - positive int; width (in pixels) of area where the timer text should be
+    """
     ocr_matching = True
     while ocr_matching:
         if isinstance(timer_ref, str):
@@ -49,8 +61,8 @@ def check_timer(kc_window, timer_ref, dir, width):
         ocr_matching, timer = ocr_check(timer)
     return timer
 
-# OCR character corrections and check
 def ocr_check(timer):
+    """OCR character checking"""
     timer = (
         timer.replace('O', '0').replace('o', '0').replace('D', '0')
         .replace('Q', '0').replace('@', '0').replace('l', '1').replace('I', '1')
@@ -104,7 +116,7 @@ def rnavigation(kc_window, destination, max=0):
     # Look at all the things we can click!
     menu_main_options = ['menu_main_sortie.png', 'menu_main_fleetcomp.png', 'menu_main_resupply.png',
         'menu_main_equip.png', 'menu_main_repair.png', 'menu_main_development.png']
-    menu_top_options = ['menu_top_profile.png', 'menu_top_encyclopedia.png', 'menu_top_inventory.png',
+    menu_top_options = ['menu_top_encyclopedia.png', 'menu_top_inventory.png',
         'menu_top_furniture.png', 'menu_top_shop.png', 'menu_top_quests.png']
     menu_side_options = ['menu_side_fleetcomp.png', 'menu_side_resupply.png', 'menu_side_equip.png',
         'menu_side_repair.png', 'menu_side_development.png']


### PR DESCRIPTION
- Repair module can now...
  - ... check repair timers of ships already being repaired.
  - ... go and continue repairs if there are still damaged ships in fleet, if docks were full previously

Other changes:
- Removed `menu_top_profile.png` from list of possible random menu items to hit. Some issue with part of DMM site showing up and interfering with clicks
- Make it so fleets received on script start are resupplied before being attempted to be sent out again
- Refactored check_timer function
- Other misc bugfixes/tweaks
