### PR TITLE
Fix combat.py homescreen and rejigger_mouse

### DIFF
--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -155,6 +155,7 @@ class Combat:
                 if self.kc_window.exists('combat_flagship_dmg.png'):
                     wait_and_click(self.kc_window, 'combat_flagship_dmg.png')
                     sleep(3)
+                rejigger_mouse(self.kc_window, 370, 770, 100, 400)
                 # Check to see if we're back at Home screen
                 if self.kc_window.exists('menu_main_sortie.png'):
                     log_success("Sortie complete!")

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -204,7 +204,7 @@ class Combat:
             # Now check for formation select, night battle prompt, or
             # post-battle report
             log_msg("Spinning compass!")
-            rejigger_mouse(self.kc_window, 50, 350, 0, 180)
+            rejigger_mouse(self.kc_window, 50, 350, 0, 150)
             # Restart this loop in case there's another compass coming up
             sleep(6)
             self.loop_pre_combat(nodes_run)
@@ -212,7 +212,7 @@ class Combat:
         elif check_and_click(self.kc_window, Pattern('formation_%s.png' % self.formations[nodes_run]).similar(0.95)):
             # Now check for night battle prompt or post-battle report
             log_msg("Selecting fleet formation!")
-            rejigger_mouse(self.kc_window, 50, 750, 0, 180)
+            rejigger_mouse(self.kc_window, 50, 750, 0, 150)
             sleep(10)
             self.loop_post_formation()
         # Check for catbomb

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -156,7 +156,7 @@ class Combat:
                     wait_and_click(self.kc_window, 'combat_flagship_dmg.png')
                     sleep(3)
                 # Check to see if we're back at Home screen
-                if self.kc_window.exists('menu_main_home.png'):
+                if self.kc_window.exists('menu_main_sortie.png'):
                     log_success("Sortie complete!")
                     sortie_underway = False
                     return self.damage_counts


### PR DESCRIPTION
- Revert changes in 2fa417e857efe38e4e5e3e28ebc9ba5c5e3c3066
- Rejigger_mouse before checking Homescreen to make sure that menu_main_sortie.png exist
- Edit some rejigger coordinate offsets (after spinning compass and after choosing formation) to avoid mouse hovers target png(s) at night battle confirm screen
