### PR TITLE
Connects to #118

### DIFF
--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -292,6 +292,8 @@ def get_config():
         if settings['combined_fleet']:
             # Remove fleet 2 from expedition list if combined fleet is enabled
             settings['expedition_id_fleet_map'].pop(2, None)
+            # Disable PvP if combined fleet is enabled
+            settings['pvp_enabled'] = False
         settings['nodes'] = config.getint('Combat', 'Nodes')
         settings['node_selects'] = config.get('Combat', 'NodeSelects').replace(' ', '').split(',')
         settings['formations'] = config.get('Combat', 'Formations').replace(' ', '').split(',')


### PR DESCRIPTION
Related to #118. Automatically turn off PvP (along with expedition for fleet2) if Combined Fleet is enabled.
