### PR TITLE
Quests and more

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -170,6 +170,12 @@ PortCheck = False
 # has been obtained. Only applicable to the monthly EOs (1-5, 2-5, 3-5, 4-5, 5-5).
 MedalStop = False
 
+# WARNING: READ THIS
+# Whether or not to 'push' past the max number of defined combat nodes, REGARDLESS OF THE STATE
+# OF YOUR FLEET. Only do this if the last node is a resource/non-combat node, like the end of 1-6
+# and your path is 100% fixed!!! YOU MAY LOSE SHIPS WITH THIS SET TO TRUE.
+LastNodePush: False
+
 
 [Quests]
 # Set to True if you want kancolle-auto to manage quests; False if not.

--- a/config.ini
+++ b/config.ini
@@ -178,7 +178,7 @@ Enabled: True
 # Quests to check for. Please check the Wiki linked above for a list of supported quests. Defaults
 # to a list of most generic quests. kancolle-auto will ignore quests if they are not completable
 # as specified by your config (if PvP is disabled, PvP quests will not be activated, and so on).
-Quests: bd1, bd2, bd3, bd4, bd5, bd6, bd8, bw1, bw2, bw3, bw4, bw5, c2, c3, c4, c8, d2, d3, d4, d9, d11, e3, e4
+Quests: bd1, bd2, bd3, bd4, bd5, bd6, bd7, bd8, bw1, bw2, bw3, bw4, bw5, c2, c3, c4, c8, d2, d3, d4, d9, d11, e3, e4
 
 # How often should quests be checked? Settings this to 1 will make quests be checked after every
 # expedition and sortie. Default is 3.

--- a/config.ini
+++ b/config.ini
@@ -178,7 +178,7 @@ Enabled: True
 # Quests to check for. Please check the Wiki linked above for a list of supported quests. Defaults
 # to a list of most generic quests. kancolle-auto will ignore quests if they are not completable
 # as specified by your config (if PvP is disabled, PvP quests will not be activated, and so on).
-Quests: bd1, bd2, bd3, bd4, bd5, bd6, bd7, bd8, bw1, bw2, bw3, bw4, bw5, c2, c3, c4, c8, d2, d3, d4, d9, d11, e3, e4
+Quests: bd1, bd2, bd3, bd4, bd5, bd6, bd7, bd8, bw1, bw2, bw3, bw4, bw5, bw6, bw7, c2, c3, c4, c8, d2, d3, d4, d9, d11, e3, e4
 
 # How often should quests be checked? Settings this to 1 will make quests be checked after every
 # expedition and sortie. Default is 3.

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -257,26 +257,24 @@ class Combat:
                 # Set next sortie time to soon in case we have no failures or additional nodes
                 self.next_sortie_time_set(0, 0, 2)
                 # If required number of nodes have been run, fall back
-                if nodes_run >= self.nodes and not self.last_node_push:
+                if nodes_run >= self.nodes:
+                    if self.last_node_push:
+                        log_warning("Pushing to next node...")
+                        wait_and_click(self.kc_region, 'combat_nextnode.png', 30)
+                        wait_and_click(self.kc_region, 'next_alt.png', 30)
+                    else:
                     log_msg("Ran the required number of nodes. Falling back!")
                     wait_and_click(self.kc_region, 'combat_retreat.png', 30)
                     sortie_underway = False
                     return (continue_combat, True)
                 # If fleet is damaged, fall back
                 if self.count_damage_above_limit('retreat') > 0 or self.damage_counts[2] > 0:
-                    if nodes_run >= self.nodes and self.last_node_push:
-                        # UNLESS the LastNodePush flag is set
-                        pass
-                    else:
-                        log_warning("Ship(s) in condition at or below retreat threshold! Ceasing sortie!")
-                        wait_and_click(self.kc_region, 'combat_retreat.png', 30)
-                        sortie_underway = False
-                        return (continue_combat, True)
+                    log_warning("Ship(s) in condition at or below retreat threshold! Ceasing sortie!")
+                    wait_and_click(self.kc_region, 'combat_retreat.png', 30)
+                    sortie_underway = False
+                    return (continue_combat, True)
                 sleep(3)
-                if nodes_run >= self.nodes and self.last_node_push:
-                    log_warning("Pushing to next node...")
-                else:
-                    log_msg("Continuing on to next node...")
+                log_msg("Continuing on to next node...")
                 wait_and_click(self.kc_region, 'combat_nextnode.png', 30)
         else:
             if self.kc_region.exists('combat_nogo_repair.png'):

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -289,9 +289,6 @@ class Combat:
             sleep_fast()
             # If compass, press it
             if check_and_click(self.kc_region, 'compass.png', expand_areas('compass')):
-                # Rework for new resupply screen
-                self.kc_region.click(self.kc_region.getLastMatch())
-                # Now check for formation select, night battle prompt, or post-battle report
                 log_msg("Spinning compass!")
                 rejigger_mouse(self.kc_region, 50, 350, 0, 100)
                 # Restart this loop in case there's another compass coming up

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -103,6 +103,7 @@ class Combat:
         return True
 
     # Navigate to Sortie menu and click through sortie!
+    # Returns tuple of booleans: (continue sorties?, sortie passed pre-check?)
     def go_sortie(self):
         continue_combat = True
         rejigger_mouse(self.kc_region, 50, 750, 0, 100)
@@ -136,7 +137,7 @@ class Combat:
             if self.kc_region.exists('combat_start_warning_shipsfull.png'):
                 log_warning("Port is full! Please make some room for new ships! Sortie cancelled!")
                 self.next_sortie_time_set(0, 15, 5)
-                return continue_combat
+                return (continue_combat, False)
         wait_and_click(self.kc_region, 'decision.png')
         sleep(1)
         rejigger_mouse(self.kc_region, 50, 750, 0, 400)
@@ -145,28 +146,28 @@ class Combat:
             if self.kc_region.exists('combat_start_warning_shipsfull_event.png'):
                 log_warning("Port is full for event! Please make some room for new ships! Sortie cancelled!")
                 self.next_sortie_time_set(0, 15, 5)
-                return continue_combat
+                return (continue_combat, False)
         if self.combined_fleet:
             # If combined fleet, check damage and morale on both pages
             if not self.pre_sortie_check():
-                return continue_combat
+                return (continue_combat, False)
             check_and_click(global_regions['fleet_flags_sec'], 'fleet_2.png', expand_areas('fleet_id'))
             sleep_fast()
             if not self.pre_sortie_check(True):
-                return continue_combat
+                return (continue_combat, False)
             check_and_click(global_regions['fleet_flags_sec'], 'fleet_1.png', expand_areas('fleet_id'))
             sleep_fast()
         else:
             # If not combined fleet, check damage and morale only on Fleet 1
             if not self.pre_sortie_check():
-                return continue_combat
+                return (continue_combat, False)
         # Check fleet damage state
         if self.damage_counts[2] > 0:
             log_warning("Ship(s) in critical condition! Sortie cancelled!")
-            return continue_combat
+            return (continue_combat, False)
         if self.count_damage_above_limit('repair') > 0:
             log_warning("Ships (%d) in condition below repair threshold! Sortie cancelled!" % self.count_damage_above_limit('repair'))
-            return continue_combat
+            return (continue_combat, False)
         if not self.kc_region.exists(Pattern('combat_start_disabled.png').exact()):
             log_success("Commencing sortie!")
             wait_and_click(self.kc_region, 'combat_start.png')
@@ -181,7 +182,7 @@ class Combat:
                 if check_and_click(global_regions['next'], 'next_alt.png', expand_areas('next')):
                     log_success("Sortie complete!")
                     sortie_underway = False
-                    return continue_combat
+                    return (continue_combat, True)
                 # If night battle prompt, proceed based on node and user config
                 if self.kc_region.exists('combat_nb_retreat.png'):
                     if self.night_battles[nodes_run] == 'True':
@@ -248,7 +249,7 @@ class Combat:
                     if fcf_retreated:
                         # If a ship was retreated using FCF, mod the damage counts properly to reflect this
                         self.damage_counts[2] += 1
-                    return continue_combat
+                    return (continue_combat, True)
                 # We ran a node, so increase the counter
                 nodes_run += 1
                 rejigger_mouse(self.kc_region, 50, 750, 0, 100)
@@ -259,13 +260,13 @@ class Combat:
                     log_msg("Ran the required number of nodes. Falling back!")
                     wait_and_click(self.kc_region, 'combat_retreat.png', 30)
                     sortie_underway = False
-                    return continue_combat
+                    return (continue_combat, True)
                 # If fleet is damaged, fall back
                 if self.count_damage_above_limit('retreat') > 0 or self.damage_counts[2] > 0:
                     log_warning("Ship(s) in condition at or below retreat threshold! Ceasing sortie!")
                     wait_and_click(self.kc_region, 'combat_retreat.png', 30)
                     sortie_underway = False
-                    return continue_combat
+                    return (continue_combat, True)
                 sleep(3)
                 log_msg("Continuing on to next node...")
                 wait_and_click(self.kc_region, 'combat_nextnode.png', 30)
@@ -279,7 +280,7 @@ class Combat:
             elif self.area_num == 'E' and self.kc_region.exists('combat_start_warning_shipsfull_event.png'):
                 log_warning("Port is full for event! Please make some room for new ships! Sortie cancelled!")
                 self.next_sortie_time_set(0, 15, 5)
-        return continue_combat
+        return (continue_combat, True)
 
     def loop_pre_combat(self, nodes_run):
         # Check for compass, formation select, night battle prompt, or post-battle report

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -316,7 +316,7 @@ class Combat:
                 loop_pre_combat_stop = True
                 break
             # If formation select, select formation based on user config
-            elif nodes_run <= len(self.formations) and check_and_click(global_regions['formation_%s' % self.formations[nodes_run]], 'formation_%s.png' % self.formations[nodes_run]):
+            elif nodes_run < len(self.formations) and check_and_click(global_regions['formation_%s' % self.formations[nodes_run]], 'formation_%s.png' % self.formations[nodes_run]):
                 # Now check for night battle prompt or post-battle report
                 log_msg("Selecting fleet formation!")
                 sleep(5)

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -574,7 +574,7 @@ class PvP:
         while not check_and_click(global_regions['next'], 'next.png', expand_areas('next')):
             pass
         sleep(2)
-        while not kc_region.exists('menu_main_sortie.png'):
+        while not self.kc_region.exists('menu_main_sortie.png'):
             check_and_click(global_regions['next'], 'next.png', expand_areas('next'))
             sleep_fast()
         log_msg("PvP complete!")

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -259,12 +259,13 @@ class Combat:
                 # If required number of nodes have been run, fall back
                 if nodes_run >= self.nodes:
                     if self.last_node_push:
+                        # Unless the PushLastNode flag is set, then push!
                         log_warning("Pushing to next node...")
                         wait_and_click(self.kc_region, 'combat_nextnode.png', 30)
                         wait_and_click(self.kc_region, 'next_alt.png', 30)
                     else:
-                    log_msg("Ran the required number of nodes. Falling back!")
-                    wait_and_click(self.kc_region, 'combat_retreat.png', 30)
+                        log_msg("Ran the required number of nodes. Falling back!")
+                        wait_and_click(self.kc_region, 'combat_retreat.png', 30)
                     sortie_underway = False
                     return (continue_combat, True)
                 # If fleet is damaged, fall back

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -565,8 +565,10 @@ class PvP:
         check_and_click(self.kc_region, 'combat_nb_fight.png')
         while not check_and_click(global_regions['next'], 'next.png', expand_areas('next')):
             pass
-        sleep_fast()
-        wait_and_click(global_regions['next'], 'next.png', 30, expand_areas('next'))
+        sleep(2)
+        while not kc_region.exists('menu_main_sortie.png'):
+            check_and_click(global_regions['next'], 'next.png', expand_areas('next'))
+            sleep_fast()
         log_msg("PvP complete!")
         return True
 

--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -158,7 +158,7 @@ def expedition_action_wrapper():
 
 # Navigate to and send expeditions
 def expedition_action(fleet_id):
-    global fleet_needs_resupply, expedition_item, settings
+    global kc_window, fleet_needs_resupply, expedition_item, settings
     for expedition in expedition_item.expedition_list:
         if fleet_id == 'all':
             pass
@@ -171,6 +171,9 @@ def expedition_action(fleet_id):
             resupply()
             expedition_item.go_expedition()
         fleet_needs_resupply[expedition.fleet_id - 1] = False
+        sleep(2)
+        if kc_window.exists('catbomb.png') and settings['recovery_method'] != 'None':
+            refresh_kancolle('Post-expedition crash')
 
 # Actions involved in conducting PvPs
 def pvp_action():

--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -429,8 +429,13 @@ def refresh_kancolle(e):
             sleep(1)
             type(Key.SPACE)
         # The Game Start button is there and active, so click it to restart
-        wait_and_click(kc_window, Pattern('game_start.png').exact(), WAITLONG)
+        while not kc_window.exists(Pattern('game_start.png').similar(0.999)):
+            sleep(2)
+        check_and_click(kc_window, 'game_start.png')
         last_refresh = datetime.datetime.now()
+        sleep(2)
+        # Re-initialize kancolle-auto post-catbomb
+        init()
     else:
         log_error("Non-catbomb script crash, or catbomb script crash w/ unsupported Viewer!")
         print e

--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -374,6 +374,7 @@ def get_config():
         settings['check_fatigue'] = config.getboolean('Combat', 'CheckFatigue')
         settings['port_check'] = config.getboolean('Combat', 'PortCheck')
         settings['medal_stop'] = config.getboolean('Combat', 'MedalStop')
+        settings['last_node_push'] = config.getboolean('Combat', 'LastNodePush')
         log_success("Combat enabled!")
     else:
         settings['combat_enabled'] = False

--- a/kancolle_auto.sikuli/quests.sikuli/quests.py
+++ b/kancolle_auto.sikuli/quests.sikuli/quests.py
@@ -240,7 +240,7 @@ class Quests:
                         self.quest_tree.add_children('bd2', [QuestNode('bd3', [3, 0, 0])])
                     if 'bd5' in self.quests_checklist:
                         self.quest_tree.add_children('bd2', [QuestNode('bd5', [3, 0, 0])])
-                        if 'bd7' in self.quests_checklist and self.combat_area == 2:
+                        if 'bd7' in self.quests_checklist and self.combat_area == '2':
                             self.quest_tree.add_children('bd5', [QuestNode('bd7', [5, 0, 0])])
                             if 'bd8' in self.quests_checklist:
                                 self.quest_tree.add_children('bd7', [QuestNode('bd8', [2, 0, 0])])
@@ -248,13 +248,13 @@ class Quests:
                             self.quest_tree.add_children('bd5', [QuestNode('bw2', [5, 0, 0])])
                             if 'bw5' in self.quests_checklist:
                                 self.quest_tree.add_children('bw2', [QuestNode('bw5', [5, 0, 0])])
-                                if 'bw6' in self.quests_checklist and self.combat_area == 4:
+                                if 'bw6' in self.quests_checklist and self.combat_area == '4':
                                     self.quest_tree.add_children('bw5', [QuestNode('bw6', [12, 0, 0])])
                                     #if 'bw8' in self.quests_checklist:
                                     #    self.quest_tree.add_children('bw6', [QuestNode('bw8', [1, 0, 0])])
                                     #    if 'bw9' in self.quests_checklist:
                                     #        self.quest_tree.add_children('bw8', [QuestNode('bw9', [2, 0, 0])])
-                                if 'bw7' in self.quests_checklist and self.combat_area == 3 and (self.combat_subarea == 3 or self.combat_subarea == 4 or self.combat_subarea == 5):
+                                if 'bw7' in self.quests_checklist and self.combat_area == '3' and (self.combat_subarea == '3' or self.combat_subarea == '4' or self.combat_subarea == '5'):
                                         self.quest_tree.add_children('bw5', [QuestNode('bw7', [5, 0, 0])])
                     if 'bw1' in self.quests_checklist:
                         self.quest_tree.add_children('bd2', [QuestNode('bw1', [12, 0, 0])])

--- a/kancolle_auto.sikuli/quests.sikuli/quests.py
+++ b/kancolle_auto.sikuli/quests.sikuli/quests.py
@@ -98,14 +98,14 @@ class Quests:
             page_backtrack = None
             disable = 'c'
             toggled_quests = list(self.activated_sortie_quests)
-            temp_quests_checklist_queue = self.sortie_quests_checklist_queue
+            temp_quests_checklist_queue = [q for q in self.quests_checklist_queue if q[0] != 'c']
         elif mode == 'pvp':
             # Enable PvP quests, disable Sortie quests
             page_continue = 'quests_next_page.png'
             page_backtrack = 'quests_prev_page.png'
             disable = 'b'
             toggled_quests = list(self.activated_pvp_quests)
-            temp_quests_checklist_queue = self.pvp_quests_checklist_queue
+            temp_quests_checklist_queue = [q for q in self.quests_checklist_queue if q[0] != 'b']
         while start_check:
             toggled_quests.extend(temp_quests_checklist_queue)
             toggled_quests = list(set(toggled_quests))


### PR DESCRIPTION
- Implement `LastNodePush`, which makes kancolle-auto 'push' past the last specified combat node, regardless of fleet damage states. Useful for maps where the last node is a resource/non-combat node like 1-6
- Improve tracking of completed sorties
- Bugfix in PvP module
- Bugfix in Quests module
