### PR TITLE
Fixed now_time no reference when only pvp enabled

### DIFF
--- a/kancolle_auto.sikuli/kancolle_auto.py
+++ b/kancolle_auto.sikuli/kancolle_auto.py
@@ -446,6 +446,7 @@ def kancolle_auto_wrapper():
             if jst_convert(now_time).hour == 6 and quest_reset_skip is True:
                 quest_reset_skip = False
         if settings['pvp_enabled']:
+            now_time = datetime.datetime.now()
             if now_time > next_pvp_time:
                 idle = False
                 pvp_action()


### PR DESCRIPTION
If pvp is enabled, sometimes this error appears:

>[error] script [ /home/waicool20/bin/kancolle-auto/kancolle_auto.sikuli ] stopped with error in line 523
[error] UnboundLocalError ( local variable 'now_time' referenced before assignment )
[error] --- Traceback --- error source first
line: module ( function ) statement 
449: main (  kancolle_auto_wrapper )     if now_time > next_pvp_time:
523: main (  <module> )     kancolle_auto_wrapper()
[error] --- Traceback --- end --------------