### PR TITLE
Fixing issue #264

### DIFF
--- a/kancolle_auto.sikuli/util.sikuli/util.py
+++ b/kancolle_auto.sikuli/util.sikuli/util.py
@@ -1,5 +1,6 @@
 import ConfigParser, datetime
 from sikuli import *
+from org.sikuli.script import *
 from random import uniform, randint, choice
 from time import sleep as tsleep, strftime
 from re import match
@@ -59,8 +60,7 @@ def check_ocr(kc_region, text_ref, dir, width):
             text = kc_region.find(text_ref).right(width).text().encode('utf-8')
         elif dir == 'l':
             text = kc_region.find(text_ref).left(width).text().encode('utf-8')
-    else:
-    # elif isinstance(text_ref, Match):
+    elif isinstance(text_ref, Match):
         if dir == 'r':
             text = text_ref.right(width).text().encode('utf-8')
         elif dir == 'l':

--- a/kancolle_auto.sikuli/util.sikuli/util.py
+++ b/kancolle_auto.sikuli/util.sikuli/util.py
@@ -59,7 +59,8 @@ def check_ocr(kc_region, text_ref, dir, width):
             text = kc_region.find(text_ref).right(width).text().encode('utf-8')
         elif dir == 'l':
             text = kc_region.find(text_ref).left(width).text().encode('utf-8')
-    elif isinstance(text_ref, Match):
+    else:
+    # elif isinstance(text_ref, Match):
         if dir == 'r':
             text = text_ref.right(width).text().encode('utf-8')
         elif dir == 'l':


### PR DESCRIPTION
Got really annoyed I just had to read up some python for debugging haha, since its almost impossible to run sub switch configurations smoothly without a crash at this point.

So for some reason text_ref is not instance of str or Match causing an error that variable text is unreferenced, and since lines 450-457 in combat.py simply ignore the exception, the error is delegated to a seemingly unrelated part of the code (line 648 combat.py). With this change it reads the timer correctly without a problem. And also simply throwing an exception away is pretty bad, a stacktrace is always helpful for debugging.

And well since there are only 2 options, it might be better to default to Match anyways, even better is probably to add a text = "" assignment to the beginning of the function so that the check_timer function can loop until it reaches the fail limit even if the OCR fails.