### PR TITLE
Repair enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Thumbs.db
 Sublime files
 *.sublime-project
 *.sublime-workspace
+
+# KAGA
+crashes

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -452,13 +452,13 @@ class Combat:
                 timer = self.timer_end(int(repair_timer[0:2]), int(repair_timer[3:5]) - 1)
                 self.repair_timers.append(timer)
             self.repair_timers.sort()
+            self.next_sortie_time_set()
         except:
             pass
         try:
             for i in self.kc_region.findAll('repair_empty.png'):
                 empty_docks += 1
         except:
-            self.next_sortie_time_set()
             log_warning("Cannot repair; docks are full. Checking back at %s!" % self.next_sortie_time.strftime("%Y-%m-%d %H:%M:%S"))
         if empty_docks > 0:
             log_msg("Attempting to conduct repairs on %d ship(s)!" % self.count_damage_above_limit('repair'))

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -323,8 +323,7 @@ class Combat:
         else:
             if self.kc_region.exists('combat_nogo_repair.png'):
                 log_warning("Cannot sortie due to ships under repair!")
-                self.next_sortie_time_set(0, 5, 5)
-                # Expand on this so it goes to repair menu and recheck?
+                self.go_repair()
             elif self.kc_region.exists('combat_nogo_resupply.png'):
                 log_warning("Cannot sortie due to ships needing resupply!")
             elif self.area_num == 'E' and self.kc_region.exists('combat_start_warning_shipsfull_event.png'):
@@ -461,6 +460,7 @@ class Combat:
         except:
             self.next_sortie_time_set()
             log_warning("Cannot repair; docks are full. Checking back at %s!" % self.next_sortie_time.strftime("%Y-%m-%d %H:%M:%S"))
+            return
         if empty_docks > 0:
             log_msg("Attempting to conduct repairs on %d ship(s)!" % self.count_damage_above_limit('repair'))
             repair_queue = empty_docks if self.count_damage_above_limit('repair') > empty_docks else self.count_damage_above_limit('repair')

--- a/kancolle_auto.sikuli/combat.sikuli/combat.py
+++ b/kancolle_auto.sikuli/combat.sikuli/combat.py
@@ -521,6 +521,9 @@ class Combat:
                 log_msg("%d ships needing repairs left..." % self.count_damage_above_limit('repair'))
         # If submarine switching is enabled, run through it if repairs were required
         if self.submarine_switch:
+            # Set fastest repair time (which might be a sub) as next sortie time to save time
+            if len(self.repair_timers) > 0:
+                self.next_sortie_time_set()
             if self.switch_sub():
                 log_msg("Attempting to switch out submarines!")
                 # If switch_subs() returns True (all ships being repaired are switched out)


### PR DESCRIPTION
Just some more enhancements after studying the code of kancolle auto

Also added return statement if docks are full, since the code below
shouldn't be executing anyways. Without it the next sortie time tends
to reset to 0 if sub switching is enabled even if their are still subs
to be repaired. Causing a loop.

It starts the next sortie immediately, sees that a sub needs repair, goes to repair screen to find out that there are repairs still goes on, then goes trying to sub switch again which resets the wait time. Rinse and repeat.

Example log:

```
[2017-01-29 02:38:40] At Home!
[2017-01-29 02:38:40] Are there returning expeditions to receive?
[2017-01-29 02:38:43] No, no fleets to receive!
[2017-01-29 02:38:44] Navigating to repair screen with 0 sidestep(s)!
[log] CLICK on L(186,438)@S(0)[0,0 1920x1080] (521 msec)
[2017-01-29 02:38:49] Got invalid timer ()... trying again!
[2017-01-29 02:38:51] Got valid timer (00:12:55)!
[2017-01-29 02:38:51] Got valid timer (00:09:28)!
[2017-01-29 02:38:54] Cannot repair; docks are full. Checking back at 2017-01-29 02:46:51!       <----- Sets wait time correctly  
[2017-01-29 02:38:58] Navigating to fleetcomp screen with 1 sidestep(s)!
[log] CLICK on L(118,395)@S(0)[0,0 1920x1080] (522 msec)
[log] CLICK on L(108,214)@S(0)[0,0 1920x1080] (522 msec)
[2017-01-29 02:39:11] No ships being repaired at the moment. Continuing sorties!      <-----Got reset
[2017-01-29 02:39:11] Attempting to switch out submarines!
[2017-01-29 02:39:11] Lets resupply fleets!
[2017-01-29 02:39:18] Navigating to resupply screen with 0 sidestep(s)!
[log] CLICK on L(88,292)@S(0)[0,0 1920x1080] (523 msec)
[log] CLICK on L(203,206)@S(0)[0,0 1920x1080] (522 msec)
[2017-01-29 02:39:24] Done resupplying!
[2017-01-29 02:39:24] Focus on KanColle!
[log] App.focus:  [803:Chromium]
[2017-01-29 02:39:39] Going home with 0 or less sidestep(s)!
[log] CLICK on L(157,354)@S(0)[0,0 1920x1080] (521 msec)
```